### PR TITLE
Fix compiler warning

### DIFF
--- a/examples/DeviceTypeTest/DeviceTypeTest.ino
+++ b/examples/DeviceTypeTest/DeviceTypeTest.ino
@@ -28,7 +28,7 @@ void loop() {
     std::string bleDevAlias("S");
     auto wiredDevType = DeviceTypeRegistry::GetDeviceType(wiredDevLabel)
         .value_or(DeviceType("undefined"));
-    auto wired = DeviceTypeRegistry::GetDevicePlatform(wiredDevType);
+    [[maybe_unused]]auto wired = DeviceTypeRegistry::GetDevicePlatform(wiredDevType);
     Serial.println(wiredDevLabel.c_str());
     Serial.println(deviceLabel(wiredDevType));
     Serial.println(devicePlatformLabel(wiredDevType));
@@ -39,7 +39,7 @@ void loop() {
         .value_or(DeviceType("undefined_ble_type"));
 
     Serial.printf("type retrieved with alias matches original: %i\n", bleDevType==bleDevType2);
-    auto ble = DeviceTypeRegistry::GetDevicePlatform(bleDevType2);
+    [[maybe_unused]]auto ble = DeviceTypeRegistry::GetDevicePlatform(bleDevType2);
 
     Serial.println(deviceLabel(bleDevType2));
     Serial.println(devicePlatformLabel(bleDevType));

--- a/src/Measurement.h
+++ b/src/Measurement.h
@@ -44,11 +44,12 @@ struct Measurement {
     Measurement(const MetaData& metadata, const SignalType signalType, const DataPoint& dataPoint):
         metaData{metadata}, signalType{signalType}, dataPoint{dataPoint}{}
     Measurement():
-        dataPoint{0,0},signalType{SignalType::UNDEFINED},metaData{MetaData::DEVICE_UNDEFINED}{}
+        metaData{MetaData::DEVICE_UNDEFINED}, signalType{SignalType::UNDEFINED}, dataPoint{0,0}{}
 
-    DataPoint dataPoint{0,0};
-    SignalType signalType{SignalType::UNDEFINED};
     MetaData metaData{MetaData::DEVICE_UNDEFINED};
+    SignalType signalType{SignalType::UNDEFINED};
+    DataPoint dataPoint{0,0};
+    
 };
 
 /**


### PR DESCRIPTION
The members of measurement are not initialized in the order of their declaration.