### PR TITLE
Provide a wrapper for c-function pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.9.2] - 2025-09-15
+
+### Fixed
+
+- Use something more safe than c-poiners!
+
 ## [0.9.1] - 2025-09-15
 
 ### Fixed

--- a/examples/BLE_example/BLE_example.ino
+++ b/examples/BLE_example/BLE_example.ino
@@ -145,12 +145,19 @@ void decodeAndPrintBLEAdvertisement(const std::string &data) {
         measurement.signalType = it->first;
 
         measurement.dataPoint.t_offset = millis();
-        uint16_t rawValue = it->second.decodingFunction(
+        auto decodingFunction = it->second.decodingFunction;
+        if (!decodingFunction ){
+            Serial.println("no decoding function defined");
+            continue;
+        
+        }
+        uint16_t rawValue = decodingFunction(
             getRawValue(data, 6 + it->second.offset));
         measurement.dataPoint.value = static_cast<float>(rawValue);
 
         /* MetaData skipped in this example as information for fields deviceID
          * and deviceType are not included in ManufacturerData */
         printMeasurementWithoutMetaData(measurement);
+        
     }
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Sensirion UPT Core
-version=0.9.1
+version=0.9.2
 author=Jonas Stolle, Maximilian Paulsen
 maintainer=Sensirion AG <sensirion.com>
 sentence=Library for definitions and configurations used by other Sensirion Unified Prototyping Toolkit (UPT) libraries.

--- a/test/test_devicetype.cpp
+++ b/test/test_devicetype.cpp
@@ -1,5 +1,6 @@
 #include "DeviceType.h"
 #include "Measurement.h"
+#include "BLEProtocol.h"
 
 #include <unity.h>
 
@@ -42,6 +43,12 @@ void test_device_label() {
     TEST_ASSERT_TRUE(label == "Sht4x");
 }
 
+void test_get_sample_configuration() {
+    auto sampleConfiguration = GetSampleConfiguration(DataType::T_RH_V3);
+    TEST_ASSERT_TRUE(sampleConfiguration.sampleSlots[SignalType::TEMPERATURE_DEGREES_CELSIUS].encodingFunction);
+    TEST_ASSERT_TRUE(sampleConfiguration.sampleSlots[SignalType::RELATIVE_HUMIDITY_PERCENTAGE].encodingFunction);
+}
+
 void setup() {
     UNITY_BEGIN();
 
@@ -50,10 +57,12 @@ void setup() {
     RUN_TEST(test_get_wired_platform);
     RUN_TEST(test_get_ble_platform);
     RUN_TEST(test_device_label);
+    RUN_TEST(test_get_sample_configuration);
 
     UNITY_END();
 }
 
+[[maybe_unused]]
 void loop() {
     // not used
 }


### PR DESCRIPTION
The intialization of encoding/decoding function fails when using std::function<>. The reason for it is not fully clear and would require more time to investigate.
As a work-around we can use a simple wrapper that provides only the functionality that we require in a minimal way to prevent access to null function pointers.